### PR TITLE
Change 'Source' to 'Source with Echo'

### DIFF
--- a/setup-instructions.md
+++ b/setup-instructions.md
@@ -112,7 +112,7 @@ Go ahead and save this as `test_script.R`. You should have something like this
 <img class="center" src="/code_club/assets/images/final_script.png" width="50%">
 
 
-There are several ways to run this script. You could copy and paste all the code to the console window below. An easier way would be to click Source, and Source again. There are a few other ways to run the code in the script in your console, but this will serve us well for now...
+There are several ways to run this script. You could copy and paste all the code to the console window below. An easier way would be to click Source, and Source with Echo. There are a few other ways to run the code in the script in your console, but this will serve us well for now...
 
 <img class="center" src="/code_club/assets/images/source_script.png" width="50%">
 


### PR DESCRIPTION
A friend of mine went through the setup instructions and became confused when clicking 'Source' then 'Source' again didn't print the plot to the Plots window. I believe the instructions should say 'Source with Echo' to get this behavior. The screenshot will also need to be updated; I'll leave that to @pschloss so the IDE theme is consistent.